### PR TITLE
[FIX] BE: LoginCtrl

### DIFF
--- a/src/main/java/com/dev/wannabe/domain/home/controller/LoginController.java
+++ b/src/main/java/com/dev/wannabe/domain/home/controller/LoginController.java
@@ -43,7 +43,7 @@ public class LoginController {
             if (loginService.login(loginData)) {
                 return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.success());
             } else {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(LoginResponse.notFound());
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(LoginResponse.badRequest());
             }
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(LoginResponse.serverError());
@@ -70,7 +70,7 @@ public class LoginController {
             if (loginService.logout()) {
                 return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.success());
             } else {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(LoginResponse.notFound());
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(LoginResponse.badRequest());
             }
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(LoginResponse.serverError());

--- a/src/main/java/com/dev/wannabe/domain/home/model/dto/LoginResponse.java
+++ b/src/main/java/com/dev/wannabe/domain/home/model/dto/LoginResponse.java
@@ -23,4 +23,8 @@ public class LoginResponse {
 	public static LoginResponse serverError() {
 		return new LoginResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 오류가 발생하였습니다.");
 	}
+	
+	public static LoginResponse badRequest() {
+		return new LoginResponse(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다.");
+	}
 }


### PR DESCRIPTION
1. 로그인 컨트롤러 응갑 값중 notFound 부분을 badRequest로 변경.
 -> 기본적으로 LoginResponse 객체 내부에 잘못된 요청 처리 부분이 없었기에 해당 객체 내에 static 메서드 생성후 로그인 컨트롤러에 올바은 상태코드와 응답처리로 수정하였습니다.