### PR TITLE
[FIX] 헤더 부분, Login&Logout Alert시 footer css수정, 메인창 쪽지 아이콘 및 갯수 관련 수정

### DIFF
--- a/src/main/java/com/dev/wannabe/domain/home/controller/HomeController.java
+++ b/src/main/java/com/dev/wannabe/domain/home/controller/HomeController.java
@@ -2,6 +2,7 @@ package com.dev.wannabe.domain.home.controller;
 
 import com.dev.wannabe.domain.home.service.HomeService;
 import com.dev.wannabe.domain.home.service.LoginService;
+import com.dev.wannabe.domain.home.service.PopupMessageService;
 import com.dev.wannabe.global.model.SessionUserDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import javax.servlet.http.HttpSession;
 public class HomeController {
     private final HomeService homeService;
     private final LoginService loginService;
+    private final PopupMessageService popupMessageService;
 
     @GetMapping("/")
     public String home() {
@@ -36,6 +38,17 @@ public class HomeController {
     public String getIp(HttpServletRequest req) {
         SessionUserDTO sessionUser = loginService.getSessionUserData(req);
         return sessionUser.getAccessIp();
+    }
+
+    // 안읽은쪽지 가져오기
+    @GetMapping("/getUnreadMsg")
+    @ResponseBody
+    public String getUnreadMsg(HttpServletRequest request){
+        String userId = request.getParameter("userId");
+        System.out.println("userId : " + userId);
+        String getUnreadMsgCount = Integer.toString(popupMessageService.receiveUnreadMsgCount(userId));
+        System.out.println("getUnreadMsgCount : " + getUnreadMsgCount);
+        return getUnreadMsgCount;
     }
 
     @GetMapping("/signup")

--- a/src/main/java/com/dev/wannabe/domain/home/controller/PopupMessageController.java
+++ b/src/main/java/com/dev/wannabe/domain/home/controller/PopupMessageController.java
@@ -140,7 +140,7 @@ public class PopupMessageController {
         }
         model.addAttribute("msgList", popupMessageDTO);
 
-        int receiveMsgCount = popupMessageService.rceiveMsgCount(userId); //전체 쪽지 갯수
+        int receiveMsgCount = popupMessageService.receiveMsgCount(userId); //전체 쪽지 갯수
         model.addAttribute("receiveMsgCount", receiveMsgCount);
         int receiveUnreadMsgCount = popupMessageService.receiveUnreadMsgCount(userId); // 안읽은 쪽지 갯수
         model.addAttribute("receiveUnreadMsgCount", receiveUnreadMsgCount);

--- a/src/main/java/com/dev/wannabe/domain/home/service/LoginService.java
+++ b/src/main/java/com/dev/wannabe/domain/home/service/LoginService.java
@@ -1,6 +1,7 @@
 package com.dev.wannabe.domain.home.service;
 
 import com.dev.wannabe.domain.home.mapper.LoginMapper;
+import com.dev.wannabe.domain.home.mapper.PopupMessageMapper;
 import com.dev.wannabe.domain.home.mapper.UserLoginMapper;
 import com.dev.wannabe.domain.home.mapper.UserMapper;
 import com.dev.wannabe.domain.home.model.dto.LoginDTO;
@@ -28,6 +29,7 @@ public class LoginService {
     private final HompiMapper hompiMapper;
     private final BCryptPasswordEncoder passwordEncoder;
     private final UserLoginMapper userLoginMapper;
+    private final PopupMessageService popupMessageService;
 
     @Transactional
     public Boolean login(LoginDTO loginData) {
@@ -53,6 +55,7 @@ public class LoginService {
 
             HttpSession session = request.getSession(true);
             SessionUserDTO sessionUserDTO = createSessionUserData(loginLog);
+
             session.setAttribute("userData", sessionUserDTO);
             session.setMaxInactiveInterval(60 * 60); // 단위 : 초 -> null point exception
 

--- a/src/main/java/com/dev/wannabe/domain/home/service/PopupMessageService.java
+++ b/src/main/java/com/dev/wannabe/domain/home/service/PopupMessageService.java
@@ -26,7 +26,7 @@ public class PopupMessageService {
         return popupMessageMapper.getReceiveMsglist(userId, offset, pageSize);
     }
 
-    public int rceiveMsgCount(String userId) {
+    public int receiveMsgCount(String userId) {
         return popupMessageMapper.receiveMsgCount(userId);
     }
 

--- a/src/main/java/com/dev/wannabe/global/model/SessionUserDTO.java
+++ b/src/main/java/com/dev/wannabe/global/model/SessionUserDTO.java
@@ -21,4 +21,5 @@ public class SessionUserDTO {
     private Long hompiId;
     private String hompiURL;
     private String hompiTitle;
+
 }

--- a/src/main/resources/META-INF/mybatis/sql/home/popupMessageMapper.xml
+++ b/src/main/resources/META-INF/mybatis/sql/home/popupMessageMapper.xml
@@ -29,7 +29,7 @@
     </select>
 
     <!-- 받은 쪽지 개수 -->
-    <select id="receiveMsgCount" resultType="int">
+    <select id="receiveMsgCount" resultType="int" parameterType="String">
         SELECT COUNT(*)
         AS receiveMsg_count
         FROM FRIEND_MESSAGE
@@ -119,6 +119,7 @@
         WHERE FRIEND_USER_ID=#{userId}
     </select>
 
+    <!-- 쪽지 삭제 -->
     <delete id="msgDelete" parameterType="String">
         DELETE
             FROM FRIEND_MESSAGE

--- a/src/main/webapp/WEB-INF/views/common/layout/fragments/header.html
+++ b/src/main/webapp/WEB-INF/views/common/layout/fragments/header.html
@@ -8,7 +8,7 @@
                 <ul>
                     <li id="loginIp" class="ipDisplay" th:text="${session.userData.accessIp}">아이피</li>
                     <li id="loginName" class="nameDisplay" th:text="${session.userData.name}">이름</li>
-                    <li><img class="home-icon" src="/static/images/common/icon/icon_home.svg" alt="미니홈피"></li>
+                    <li><img class="home-icon" src="/static/images/common/icon/icon_home.svg" alt="미니홈피" th:attr="data-minihompi=${session.userData.hompiId}"></li>
                     <li><a href="/userUpdate"><img class="setting-icon" src="/static/images/common/icon/icon_setting.svg" alt="개인정보수정"></a></li>
                     <li><a href="#" id="logoutBtn" class="btn nobtn logoutBtn">로그아웃</a></li>
                 </ul>

--- a/src/main/webapp/WEB-INF/views/home/fragment/userPanel.html
+++ b/src/main/webapp/WEB-INF/views/home/fragment/userPanel.html
@@ -30,7 +30,7 @@
                                 <span class="title">쪽지</span>
                                 <div class="stat messageBox">
                                     <img src="/static/images/common/icon/new.png" alt="new">
-                                    <span class="text new" target="_blank" onclick="openPopupMessage()">30</span>
+                                    <span class="text new unReadMsgCount" target="_blank" onclick="openPopupMessage()"></span>
                                 </div>
                             </div>
                             <div class="alignBox">

--- a/src/main/webapp/static/js/home/login.js
+++ b/src/main/webapp/static/js/home/login.js
@@ -16,7 +16,6 @@ $(document).ready(function(){
             login(loginId, password);
         }
     });
-
     // content
     $("#loginBtnFragment").on("click", function(){
         let loginId = $("#loginIdFragment");

--- a/src/main/webapp/static/js/home/popupMessage.js
+++ b/src/main/webapp/static/js/home/popupMessage.js
@@ -17,8 +17,8 @@ $(document).ready(function () {
         dataType: "json",
         success: function (response) {
             userId = response.userId;
-
             if (userId) {
+                fncReceiveCount(userId);
                 loadMessages(currentReceivePage, "receive");
             }
         },
@@ -26,6 +26,7 @@ $(document).ready(function () {
             alert("비정상적인 접근입니다.");
         }
     });
+
 
     $(".receiveMsgbox>span").css({"color": "#ff8000"});
 
@@ -96,9 +97,14 @@ $(document).ready(function () {
             if (type === "receive") {
                 totalMessage = parseInt($("#popMsgListContainer").attr("data-totalunreadmsg"));
                 if (totalMessage === 0) {
+                    $(".receiveMsgCount").text();
                     $(".receiveMsgCount").removeAttr("class", "circle");
                 } else {
                     $(".receiveMsgCount").text(totalMessage);
+                    if (window.opener && !window.opener.closed) {
+                        const unReadMsgCount = $(window.opener.document).find("span.unReadMsgCount");
+                        unReadMsgCount.text(totalMessage);
+                    }
                 }
             }
 
@@ -290,10 +296,10 @@ $(document).ready(function () {
 
 /**  쪽지 팝업창 설정 **/
 function openPopupMessage() {
-    var popupW = 700;
-    var popupH = 700;
-    var left = Math.ceil((window.screen.width - popupW) / 2);
-    var top = Math.ceil((window.screen.height - popupH) / 2);
+    let popupW = 700;
+    let popupH = 700;
+    let left = Math.ceil((window.screen.width - popupW) / 2);
+    let top = Math.ceil((window.screen.height - popupH) / 2);
 
     window.open('/popupMessage/main', '쪽지 보내기',
         'width=' + popupW + ',height=' + popupH + ',left=' + left + ',top=' + top);
@@ -306,8 +312,29 @@ function fncMsgView(messageId, element, type) {
     if (type === "receive") {
         const chk = $(element).parent().attr("class");
         if (chk === "unread") {
-            let msgCount = $("span.receiveMsgCount").text();
-            $("span.receiveMsgCount").text(msgCount - 1);
+            let receiveMsgCount = $("span.receiveMsgCount");
+            let msgCount = receiveMsgCount.text();
+            msgCount = msgCount-1;
+            receiveMsgCount.text(msgCount);
+            console.log("msgCount : " + msgCount);
+
+            if (window.opener && !window.opener.closed) {
+                const unReadMsgCount = $(window.opener.document).find("span.unReadMsgCount");
+                const newIcon = $(window.opener.document).find(".messageBox > img")
+                    unReadMsgCount.text(msgCount);
+                if (msgCount <= "0") {
+                    newIcon.remove();
+                }
+
+            }
+            if (msgCount <= "0") {
+                console.log("receiveMsgCount 지원")
+                receiveMsgCount.text("");
+                receiveMsgCount.attr("class","circle").remove();
+
+            }
+
+
         }
     }
 }
@@ -431,4 +458,23 @@ function fncDeleteMsgBtn(messageType) {
             alert("삭제 중 오류가 발생했습니다.");
         }
     });
+}
+
+/* 메인 쪽지*/
+function fncReceiveCount(userId) {
+        $.ajax({
+            url: `/getUnreadMsg?userId=${userId}`,
+            type: "GET",
+            success: function (count) {
+                if (count <= 0) {
+                   $(".messageBox>img").remove();
+                }
+                $(".unReadMsgCount").text(count); // 받은 개수를 span 등에 넣어줌
+                console.log("unReadMsgCount : " + count);
+            },
+            error: function () {
+                console.error("쪽지 개수 가져오기 실패");
+            }
+        });
+
 }

--- a/src/main/webapp/static/js/ptr/header.js
+++ b/src/main/webapp/static/js/ptr/header.js
@@ -28,6 +28,10 @@ $(document).ready(() => {
 
 });
 
+$("img.home-icon").on("click", function(){
+    openPop();
+});
+
 // 미니홈피 팝업 오픈 함수
 function openPop() {
     const specs = `width=${HOMPI_WIDTH},height=${HOMPI_HEIGHT},left=${HOMPI_LEFT},top=${HOMPI_TOP}`;

--- a/src/main/webapp/static/js/ptr/login-new.js
+++ b/src/main/webapp/static/js/ptr/login-new.js
@@ -50,13 +50,15 @@ $(document).ready(function() {
             loginNew(loginIdValue, passwordValue);
         }
     });
-
     // 로그아웃 버튼 이벤트 (두 영역 통합)
     logoutButtons.click(function() {
         logout();
     });
 });
 
+$("img.home-icon").on("click", function(){
+    console.log("테스트");
+});
 
 // =========== 함수 정의 레이어 ===========
 // 로그인
@@ -69,12 +71,18 @@ function loginNew(loginIdValue, passwordValue) {
     postAjax(API.LOGIN, LoginDTO, function(response) {
 
         if(response.status === HTTP_STATUS.OK.code) {
+
             swalPopup('로그인 성공', '로그인 성공하였습니다.', 'success', '확인', '닫기')
                 .then((result) => {
+
                     if(result.isConfirmed) {
+
                         location.reload();  // 확인 버튼 누르면 html reload
                     }
                 });
+
+                document.body.classList.remove('swal2-height-auto'); //푸터 움직이는거 제거
+
         } else if (response.status === HTTP_STATUS.NOT_FOUND.code) {
             swalPopup('로그인 실패', '로그인 정보를 확인해주세요.', 'error', '확인', '닫기');
         } else if (response.status === HTTP_STATUS.SERVER_ERROR.code) {
@@ -97,6 +105,7 @@ function logout() {
                         location.reload();  // 확인 버튼 누르면 html reload
                     }
                 });
+            document.body.classList.remove('swal2-height-auto'); //푸터 움직이는거 제거
         } else if (response.status === HTTP_STATUS.NOT_FOUND.code) {
             swalPopup('로그아웃 실패', '로그아웃 정보를 확인해주세요.', 'error', '확인', '닫기');
         } else if (response.status === HTTP_STATUS.SERVER_ERROR.code) {

--- a/src/main/webapp/static/js/ptr/login-new.js
+++ b/src/main/webapp/static/js/ptr/login-new.js
@@ -56,10 +56,6 @@ $(document).ready(function() {
     });
 });
 
-$("img.home-icon").on("click", function(){
-    console.log("테스트");
-});
-
 // =========== 함수 정의 레이어 ===========
 // 로그인
 function loginNew(loginIdValue, passwordValue) {
@@ -81,7 +77,7 @@ function loginNew(loginIdValue, passwordValue) {
                     }
                 });
 
-                document.body.classList.remove('swal2-height-auto'); //푸터 움직이는거 제거
+                document.body.classList.remove('swal2-height-auto'); // footer 부분 css 위치조정
 
         } else if (response.status === HTTP_STATUS.NOT_FOUND.code) {
             swalPopup('로그인 실패', '로그인 정보를 확인해주세요.', 'error', '확인', '닫기');
@@ -105,7 +101,9 @@ function logout() {
                         location.reload();  // 확인 버튼 누르면 html reload
                     }
                 });
-            document.body.classList.remove('swal2-height-auto'); //푸터 움직이는거 제거
+            
+            document.body.classList.remove('swal2-height-auto'); //footer 부분 css 위치조정
+        
         } else if (response.status === HTTP_STATUS.NOT_FOUND.code) {
             swalPopup('로그아웃 실패', '로그아웃 정보를 확인해주세요.', 'error', '확인', '닫기');
         } else if (response.status === HTTP_STATUS.SERVER_ERROR.code) {


### PR DESCRIPTION
1. 헤더 우상단 집모양버튼 클릭시 미니홈피 이동
2. 로그인 시 알럿 떳을때 푸터 css 위치 조정
3. 로그인 프로필카드 쪽지란은 미확인 쪽지 존재시에만 N 아이콘 뜨며, 갯수 표기. 확인된 쪽지는 카운트 제외